### PR TITLE
generalize `Task`s and `TaskResult`s

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -9,10 +10,18 @@ import           Control.Distributed.Process
                    (NodeId(..))
 import           Control.Distributed.Process.Node
                    (initRemoteTable, newLocalNode, runProcess)
+import           Data.Binary
+                   (Binary)
+import           Data.Foldable
+                   (foldl')
 import           Data.Maybe
                    (fromMaybe)
+import           Data.Proxy
+                   (Proxy(Proxy))
 import           Data.String
                    (fromString)
+import           GHC.Generics
+                   (Generic)
 import           Network.Transport
                    (EndPointAddress(..))
 import           Network.Transport.TCP
@@ -21,10 +30,25 @@ import           System.Environment
                    (getArgs, getProgName, lookupEnv)
 import           System.Exit
                    (exitFailure, exitSuccess)
+import           Test.Hspec.Core.Runner
+                   (Summary(..))
 
 import           Lib
+import           TaskQueue
+import           Test
 
 ------------------------------------------------------------------------
+
+type TestTask = String
+
+data TestResult = TestResult Int Int
+  deriving (Generic, Show)
+
+instance Monoid TestResult where
+  mempty = TestResult 0 0
+  TestResult a b `mappend` TestResult c d = TestResult (a+c) (b+d)
+
+instance Binary TestResult
 
 main :: IO ()
 main = do
@@ -41,13 +65,29 @@ main = do
     "master" : host : args' -> do
       transport <- makeTransport host masterHost masterPort
       nid <- newLocalNode transport initRemoteTable
-      runProcess nid (masterP args')
+
+      let testTasks = zipWith Task (map TaskId [0..]) args'
+          n = length testTasks
+          q = foldl' enqueue mempty testTasks
+          initState = MasterState n q (mempty :: TaskResult TestResult)
+          resultAction :: TaskResult TestResult -> IO ()
+          resultAction (TaskResult tasks result') = do
+            putStrLn $ "tasks completed: " ++ show tasks
+            putStrLn $ "test summary: "    ++ show result'
+      runProcess nid (masterP initState resultAction)
+
       threadDelay (3 * 1000000)
       exitSuccess
     ["slave", host, port] -> do
       transport <- makeTransport host host port
-      nid <- newLocalNode transport initRemoteTable
-      runProcess nid (workerP masterNodeId)
+      nid       <- newLocalNode transport initRemoteTable
+
+      let testAction :: Task TestTask -> IO (TaskResult TestResult)
+          testAction (Task _ test) = do
+            Summary exs fails <- runTests test
+            return $ TaskResult mempty $ TestResult exs fails
+      runProcess nid $ workerP (Proxy :: Proxy (WorkerMessage TestResult)) masterNodeId testAction
+
       threadDelay (3 * 1000000)
       exitSuccess
     _ -> do

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,13 +1,14 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveFoldable     #-}
-{-# LANGUAGE DeriveFunctor      #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE ExplicitForAll      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Lib
   ( masterP
   , workerP
+  , MasterState (..)
+  , WorkerMessage
   )
   where
 
@@ -25,81 +26,49 @@ import           Control.Monad.State
                    (gets, modify)
 import           Data.Binary
                    (Binary)
-import           Data.Foldable
-                   (foldl')
 import           Data.Monoid
                    ((<>))
+import           Data.Proxy
+                   (Proxy(Proxy))
 import           Data.Typeable
                    (Typeable)
 import           GHC.Generics
                    (Generic)
-import           Test.Hspec.Core.Runner
-                   (Summary(..))
 import           Text.Printf
                    (printf)
 
 import           StateMachine
-
-import           Test
-
-------------------------------------------------------------------------
-
-newtype Enqueue a = Enqueue [a] deriving Show
-newtype Dequeue a = Dequeue [a] deriving Show
-
-data Queue a = Queue (Enqueue a) (Dequeue a) deriving Show
-
-instance Monoid (Queue a) where
-  mempty = mkQueue [] []
-  mappend (Queue (Enqueue es) (Dequeue ds))
-          (Queue (Enqueue fs) (Dequeue gs))
-    = mkQueue (fs ++ reverse gs ++ es) (ds)
-
-mkQueue :: [a] -> [a] -> Queue a
-mkQueue es [] = Queue (Enqueue []) (Dequeue $ reverse es)
-mkQueue es ds = Queue (Enqueue es) (Dequeue ds)
-
-enqueue :: Queue a -> a -> Queue a
-enqueue (Queue (Enqueue es) (Dequeue ds)) e = mkQueue (e:es) ds
-
-dequeue :: Queue a -> (Maybe a, Queue a)
-dequeue (Queue (Enqueue []) (Dequeue [])) = (Nothing, mempty)
-dequeue (Queue (Enqueue es) (Dequeue (d:ds))) = (Just d, mkQueue es ds)
-dequeue _ = error "unexpected invariant: front of queue is empty but rear is not"
+import           TaskQueue
 
 ------------------------------------------------------------------------
 
-data Task = Task String
-  deriving (Typeable, Generic, Show, Ord, Eq)
-
-instance Binary Task
-
-data Message
+data WorkerMessage a
   = AskForTask ProcessId
-  | DeliverTask Task
+  | TaskFinished ProcessId (TaskResult a)
+  deriving (Typeable, Generic)
+
+instance Binary a => Binary (WorkerMessage a)
+
+data MasterMessage a
+  = DeliverTask (Task a)
   | WorkDone
-  | TaskFinished ProcessId Task TaskResult
-  deriving (Typeable, Generic, Show)
+  deriving (Typeable, Generic)
 
-data TaskResult = TaskResult Int Int
-  deriving (Generic, Show)
-
-instance Binary TaskResult
-
-summaryFromTaskResult :: TaskResult -> Summary
-summaryFromTaskResult (TaskResult exs fails) = Summary exs fails
-
-instance Binary Message
+instance Binary a => Binary (MasterMessage a)
 
 ------------------------------------------------------------------------
 
-workerP :: NodeId -> Process ()
-workerP nid = do
+workerP :: forall proxy a b . (Binary a, Typeable a, Binary b, Typeable b)
+        => proxy (WorkerMessage b)
+        -> NodeId
+        -> (Task a -> IO (TaskResult b))
+        -> Process ()
+workerP proxy nid workload = do
   self <- getSelfPid
   say $ printf "slave alive on %s" (show self)
   master <- waitForMaster nid
-  send master (AskForTask self)
-  stateMachineProcess (self, master) () workerSM
+  send master (AskForTask self :: WorkerMessage b)
+  stateMachineProcess proxy (self, master) () (workerSM @a @b workload)
 
 waitForMaster :: NodeId -> Process ProcessId
 waitForMaster masterNid = do
@@ -119,36 +88,41 @@ waitForMaster masterNid = do
     ]
   maybe (waitForMaster masterNid) return mpid
 
-workerSM :: Message -> StateMachine (ProcessId, ProcessId) () Message ()
-workerSM (DeliverTask task@(Task descr)) = do
-  tell $ printf "running: %s" (show task)
-  Summary exs fails <- liftIO $ runTests descr
-  tell $ printf "done: %s" (show task)
+workerSM :: (Task a -> IO (TaskResult b))
+         -> MasterMessage a
+         -> StateMachine (ProcessId, ProcessId) () (WorkerMessage b) ()
+workerSM mapAction (DeliverTask task@(Task taskId _)) = do
+  tell $ printf "running: %s" (show taskId)
+  TaskResult _ result' <- liftIO $ mapAction task
+  tell $ printf "done: %s" (show taskId)
   (self, master) <- ask
-  master ! TaskFinished self task (TaskResult exs fails)
+  master ! TaskFinished self (TaskResult (pure taskId) result')
   master ! AskForTask self
-workerSM WorkDone = halt
-workerSM _ = error "invalid state transition"
+workerSM _ WorkDone = halt
 
 ------------------------------------------------------------------------
 
-masterP :: [String] -> Process ()
-masterP args = do
-  self <- getSelfPid
-  say $ printf "master alive on %s: %s" (show self) (unwords args)
-  register "taskQueue" self
-  let n = length args
-      q = foldl' (\akk -> (enqueue akk) . Task) mempty args
-  stateMachineProcess () (MasterState n  q  mempty) masterSM
-
-data MasterState = MasterState
-  { step    :: Int
-  , queue   :: Queue Task
-  , summary :: Summary
+data MasterState a b = MasterState
+  { step   :: Int
+  , queue  :: Queue (Task a)
+  , result :: TaskResult b
   }
 
-masterSM :: Message -> StateMachine () MasterState Message ()
-masterSM (AskForTask pid) = do
+masterP :: (Binary a, Typeable a, Binary b, Typeable b, Monoid b)
+        => MasterState a b
+        -> (TaskResult b -> IO ())
+        -> Process ()
+masterP initState reduceAction = do
+  self <- getSelfPid
+  say $ printf "master alive on %s" (show self)
+  register "taskQueue" self
+  stateMachineProcess Proxy () initState (masterSM reduceAction)
+
+masterSM :: Monoid b
+         => (TaskResult b -> IO ())
+         -> WorkerMessage b
+         -> StateMachine () (MasterState a b) (MasterMessage a) ()
+masterSM resultAction (AskForTask pid) = do
   q <- gets queue
   case dequeue q of
     (Just task, q') -> do
@@ -157,18 +131,19 @@ masterSM (AskForTask pid) = do
     (Nothing, _)    -> do
       pid ! WorkDone
       n <- gets step
-      when (n == 0) halt
-masterSM (TaskFinished pid task result) = do
-  tell $ printf "%s: %s done with %s" (show task) (show result) (show pid)
-  n <- gets step
-  summary' <- gets summary
-  let summary'' = summary' <> summaryFromTaskResult result
+      when (n == 0) $ do
+        summary' <- gets result
+        liftIO $ resultAction summary'
+        halt
+masterSM resultAction (TaskFinished pid result'@(TaskResult tasks _)) = do
+  tell $ printf "%s done with %s" (show pid) (show tasks)
+  n        <- gets step
+  summary' <- gets ((<> result') . result)
   if n == 0
   then do
-    tell $ printf "summary: " <> show summary''
+    liftIO $ resultAction result'
     halt
   else do
-    modify (\s -> s { step = pred $ step s
-                    , summary = summary''
+    modify (\s -> s { step   = pred $ step s
+                    , result = summary'
                     })
-masterSM _ = error "invalid state transition"

--- a/src/TaskQueue.hs
+++ b/src/TaskQueue.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+
+module TaskQueue where
+
+import           Data.Binary
+                   (Binary)
+import           Data.Monoid
+                   ((<>))
+import           Data.Typeable
+                   (Typeable)
+import           GHC.Generics
+                   (Generic)
+
+------------------------------------------------------------------------
+
+newtype Enqueue a = Enqueue [a]
+newtype Dequeue a = Dequeue [a]
+
+data Queue a = Queue (Enqueue a) (Dequeue a)
+
+instance Monoid (Queue a) where
+  mempty = mkQueue [] []
+  mappend (Queue (Enqueue es) (Dequeue ds))
+          (Queue (Enqueue fs) (Dequeue gs))
+    = mkQueue (fs ++ reverse gs ++ es) (ds)
+
+mkQueue :: [a] -> [a] -> Queue a
+mkQueue es [] = Queue (Enqueue []) (Dequeue $ reverse es)
+mkQueue es ds = Queue (Enqueue es) (Dequeue ds)
+
+enqueue :: Queue a -> a -> Queue a
+enqueue (Queue (Enqueue es) (Dequeue ds)) e = mkQueue (e:es) ds
+
+dequeue :: Queue a -> (Maybe a, Queue a)
+dequeue (Queue (Enqueue []) (Dequeue [])) = (Nothing, mempty)
+dequeue (Queue (Enqueue es) (Dequeue (d:ds))) = (Just d, mkQueue es ds)
+dequeue _ = error "unexpected invariant: front of queue is empty but rear is not"
+
+newtype TaskId = TaskId Integer
+  deriving (Typeable, Generic, Show)
+
+instance Binary TaskId
+
+data Task a = Task TaskId a
+  deriving (Typeable, Generic)
+
+instance Binary a => Binary (Task a)
+
+data TaskResult a = TaskResult [TaskId] a
+  deriving (Generic, Typeable)
+
+instance Monoid a => Monoid (TaskResult a) where
+  mempty = TaskResult mempty mempty
+  (TaskResult lhsIds lhs) `mappend` (TaskResult rhsIds rhs) =
+    TaskResult (lhsIds <> rhsIds) (lhs <> rhs)
+
+instance Binary a => Binary (TaskResult a)


### PR DESCRIPTION
- `Test` now separates the test logic
- `Main` defines test tasks
- `Lib` is completely task agnostic